### PR TITLE
Adding after_body hook 

### DIFF
--- a/theme-name/header.php
+++ b/theme-name/header.php
@@ -13,3 +13,9 @@
 		<?php wp_head(); ?>
 	</head>
 	<body <?php body_class(); ?>>
+	<?php
+	/**
+	 * Custom action to provide entry point
+	 * for items such as GPT tags.
+	 */
+	do_action( 'after_body' ); ?>


### PR DESCRIPTION
Adding a hook just after the opening body tag to provide an entry point to add various items such as GPT tags.